### PR TITLE
Propose using @endgroup directive instead of @end to maintain clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ By default, hook implementations inside groups are not initialized automatically
 }
 
 @end
-@end
+@endgroup
 
 __attribute__((constructor))
 static void ctor() {


### PR DESCRIPTION
Propose using `@endgroup` directive instead of `@end` to maintain clarity of encompassed `@hook`'s, without the need to introduce indentation.
